### PR TITLE
Implement FREETYPE_CUSTOM_GEOMETRY environment variable for unusual subpixel formats

### DIFF
--- a/include/freetype/ftmodapi.h
+++ b/include/freetype/ftmodapi.h
@@ -522,6 +522,9 @@ FT_BEGIN_HEADER
   FT_EXPORT( void )
   FT_Set_Default_Properties( FT_Library  library );
 
+  FT_EXPORT( void )
+  FT_Set_Custom_Geometry( FT_Library  library );
+
 
   /**************************************************************************
    *

--- a/src/base/ftinit.c
+++ b/src/base/ftinit.c
@@ -106,11 +106,112 @@
 
 #define MAX_LENGTH  128
 
+  FT_EXPORT_DEF( void )
+  FT_Set_Custom_Geometry( FT_Library  library )
+  {
+    const char*  env;
+    const char*  p;
+
+    int vecr_x = 0;
+    int vecr_y = 0;
+    int vecg_x = 0;
+    int vecg_y = 0;
+    int vecb_x = 0;
+    int vecb_y = 0;
+
+    char  buffer[MAX_LENGTH + 1];
+
+    int negative = 0;
+    int vector_index = 0;
+    int i = 0;
+    int val = 0;
+
+    env = ft_getenv( "FREETYPE_CUSTOM_GEOMETRY" );
+    if ( !env ) {
+      FT_TRACE0(("No FREETYPE_CUSTOM_GEOMETRY\n"));
+      return;
+    }
+      
+    for ( p = env; ; p++ )
+    {
+      FT_TRACE0(("FTCG: %c\n", *p));
+
+      /* skip leading whitespace and separators */
+      if ( *p == ' ' || *p == '\t' )
+        continue;
+
+      /* Read vector data */
+      if ( *p == '-') {
+        negative = 1;
+        continue;
+      }
+
+      if ( *p == ',' || !*p ) {
+        buffer[i] = '\0';
+        val = atoi(buffer);
+
+        if (negative != 0) {
+          val = -val;
+        }
+
+        negative = 0;
+        i = 0;
+        
+        if (vector_index == 0)
+          vecr_x = val;
+        else if (vector_index == 1)
+          vecr_y = val;
+        else if (vector_index == 2)
+          vecg_x = val;
+        else if (vector_index == 3)
+          vecg_y = val;
+        else if (vector_index == 4)
+          vecb_x = val;
+        else if (vector_index == 5)
+          vecb_y = val;
+        else
+          break;
+
+        if (!*p)
+          break;
+
+        vector_index++;
+
+        continue;
+      }
+
+      if (!*p)
+        break;
+
+      buffer[i++] = *p;
+    }
+
+    FT_TRACE0(("FREETYPE_CUSTOM_GEOMETRY: %d,%d %d,%d %d,%d\n", 
+      vecr_x, vecr_y,
+      vecg_x, vecg_y,
+      vecb_x, vecb_y));
+
+    //R
+    library->lcd_geometry[0].x = vecr_x;
+    library->lcd_geometry[0].y = vecr_y;
+
+    //G
+    library->lcd_geometry[1].x = vecg_x;
+    library->lcd_geometry[1].y = vecg_y;
+
+    //B
+    library->lcd_geometry[2].x = vecb_x;
+    library->lcd_geometry[2].y = vecb_y;
+  }
+
   /* documentation is in ftmodapi.h */
 
   FT_EXPORT_DEF( void )
   FT_Set_Default_Properties( FT_Library  library )
   {
+    
+    FT_Set_Custom_Geometry(library);
+
     const char*  env;
     const char*  p;
     const char*  q;


### PR DESCRIPTION
# This is a proof of concept

## Introduction

This change to the FreeType library allows for the use of a `FREETYPE_CUSTOM_GEOMETRY` environment variable to globally  set a custom subpixel layout when using font anti-aliasing.

The main purpose of this change is so that I could get proper subpixel anti-aliasing for my Samsung G8 OLED, which has a triangular subpixel layout. All of the current QD-OLED displays currently have the same kind of layout. None of the current anti-aliasing solutions take this unusual subpixel layout into consideration.

![image](https://user-images.githubusercontent.com/59981975/233756842-686b8cbe-abae-498e-9c50-3e6fe23761aa.png)

This issue also applies to RWBG pixel layouts, which are common on regular OLED displays.

A number of discussions on this issue have surfaced over the past year and a bit, mostly in the context of Windows. For example:

- https://github.com/microsoft/PowerToys/issues/25595
- https://github.com/snowie2000/mactype/issues/720

## What this does

The modifications to the FreeType library make it so that you can specify any arbitrary subpixel layout, and the library will use that layout when applying anti-aliasing.

You can specify this with the environment variable `FREETYPE_CUSTOM_GEOMETRY`, which accepts a set of offsets from the traditional RGB layout in the form of X/Y coordinates for each of the subpixels in order of R,G,B. 

Namely: `FREETYPE_CUSTOM_GEOMETRY=rx,ry,gx,gy,bx,by`

If you set this as a global environment variable, it will apply to all applications that use FreeType. You can also set this on a per-app basis, or change it as needed.

## How I use it

For my Samsung G8 OLED, the following offsets appear to provide an acceptable level of anti-aliasing without the fringing you would ordinarily see: 

`FREETYPE_CUSTOM_GEOMETRY=-21,-16,0,16,21,-16`

I place this environment variable in `/etc/environment` and it applies globally after a system restart.

## Limitations

1. This is a global setting, insofar as it does not differentiate between types of screens. So if you have two monitors, one of which has a normal subpixel layout, it will make that display look worse. As far as I know, there is no way to apply this change on a per-display basis.

2. This is a hack on top of FreeType. If this were to actually be implemented in the library, it would probably need to be refactored to use the `FREETYPE_PROPERTIES` environment variable instead of making a new one like I did here.

## Building and installing

1. Clone the repository recursively to make sure you grab all the submodules
2. Run `autogen.sh` in the root folder
3. Run `configure` in the root folder. Pay attention to where your distro currently stores `libfreetype.so` (`/usr/lib` or `/usr/local/lib`, for example) and specify the root of that as the `prefix`, such as `configure --prefix=/usr` if your library is in `/usr/lib`.
4. Run `make`
5. Run `sudo make install`

If you are on Ubuntu or its derivatives, you will likely need to copy the library over to `/lib/x86_64-linux-gnu` as well, depending on your architecture. Be aware that overwriting the library in `/lib/x86_64-linux-gnu` is going to affect all applications in the running system. You will likely need to drop into a terminal outside of your desktop interface, by running `sudo init 3` from your desktop (or by switching TTYs by using `CTRL+ALT+F3`, for example), before you copy the file over. Otherwise, your window server will probably crash before the copy completes, resulting in a borked system.